### PR TITLE
chore: rename package to kei-lisp-web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "KeiLisp-onWeb",
+  "name": "kei-lisp-web",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "KeiLisp-onWeb",
+  "name": "kei-lisp-web",
   "version": "0.1.0",
   "private": true,
   "description": "このプログラムはJSでLisp処理系を作成したものWebブラウザで実行可能にしたものです。",


### PR DESCRIPTION
## Summary
- リポジトリのリネーム (`KeiLisp-onWeb` → `kei-lisp-web`) に追従して `package.json` / `package-lock.json` の `name` フィールドを更新。
- 旧版終端タグ `legacy-v1` を `988e732` (2021/01/07 1st commit) に付与済み（このPRより前の状態を退避）。

## Scope
- README / `public/index.html` / `src/lib/**` の `KeiLisp-onWeb` 文字列は Vue3 再構築時に全面書き換え予定のため**触らない**。
- `docs/`（旧 GitHub Pages ビルド成果物）も再構築完了後に再生成するため触らない。

## Test plan
- [ ] `package.json` の `name` が `kei-lisp-web` になっている
- [ ] `package-lock.json` の `name` が `kei-lisp-web` になっている
- [ ] `legacy-v1` タグが GitHub 上に存在する