### PR TITLE
fix: shim process.stdout / stderr for the browser polyfill (blank page fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+
+# Personal files (not tracked)
+keisuke_ikeda.png

--- a/configs/cspell/project.txt
+++ b/configs/cspell/project.txt
@@ -35,6 +35,7 @@ cdr
 car
 defun
 printc
+terpri
 
 # フォント名 (CSS)
 Ricty

--- a/configs/cspell/tool.txt
+++ b/configs/cspell/tool.txt
@@ -8,6 +8,7 @@ prettierignore
 tsconfig
 gitignore
 esbuild
+unrs
 tseslint
 sonarjs
 happy-dom

--- a/configs/eslint/const/index.mjs
+++ b/configs/eslint/const/index.mjs
@@ -6,6 +6,7 @@ export const RULE_LEVEL = {
 
 export const FILES = {
   SRC: ['src/**/*.ts', 'src/**/*.vue'],
+  SRC_TS: ['src/**/*.ts'],
   CONFIG: ['*.{js,mjs,ts}', 'configs/**/*.mjs'],
   TEST: ['src/**/*.test.ts'],
 };

--- a/configs/eslint/js/index.mjs
+++ b/configs/eslint/js/index.mjs
@@ -1,0 +1,11 @@
+import js from '@eslint/js';
+
+/**
+ * ESLint config for @eslint/js.
+ */
+export const jsConfigs = [
+  js.configs.recommended,
+  {
+    rules: {},
+  },
+];

--- a/configs/eslint/typescript/index.mjs
+++ b/configs/eslint/typescript/index.mjs
@@ -1,0 +1,53 @@
+import tseslint from 'typescript-eslint';
+import { FILES, RULE_LEVEL } from '../const/index.mjs';
+
+const { SRC_TS, TEST } = FILES;
+const { ERROR, WARN, OFF } = RULE_LEVEL;
+
+/**
+ * ESLint config for typescript-eslint.
+ *
+ * strictTypeChecked を適用するが、Vue SFC (.vue) は vue-eslint-parser が
+ * 別途担当するため、ここでは対象を .ts のみに絞る。
+ */
+export const typescriptConfigs = [
+  ...tseslint.configs.strictTypeChecked.map((config) => ({
+    ...config,
+    files: [...SRC_TS, ...TEST],
+  })),
+  {
+    files: [...SRC_TS, ...TEST],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+      },
+    },
+    rules: {
+      // any の使用を禁止
+      '@typescript-eslint/no-explicit-any': ERROR,
+      // null 非許容アサーション（!）の使用を禁止
+      '@typescript-eslint/no-non-null-assertion': ERROR,
+      // デフォルトの toString のみを持つ値の文字列化を禁止
+      '@typescript-eslint/no-base-to-string': ERROR,
+      // 同型への不要な型変換 (Number(num), String(str) 等) を禁止
+      '@typescript-eslint/no-unnecessary-type-conversion': ERROR,
+      // メソッドの戻り値型に `this` 型の使用を強制
+      '@typescript-eslint/prefer-return-this-type': ERROR,
+      // NOTE: シム / composable など Vue アプリ側では static-only クラスがそもそも生まれないため無効化寄せ
+      '@typescript-eslint/no-extraneous-class': OFF,
+      // NOTE: DOM オブジェクトの chain 参照など this alias が便利なケースが Vue アプリでも発生するため無効化
+      '@typescript-eslint/no-this-alias': OFF,
+      // 型定義は interface ではなく type エイリアスを使う方針
+      '@typescript-eslint/consistent-type-definitions': [ERROR, 'type'],
+      // NOTE: strictTypeChecked がこのルールを有効化するため、unusedImportsConfigs 側の OFF が上書きされないよう再度 OFF にする（unused-imports/no-unused-vars に委譲）
+      '@typescript-eslint/no-unused-vars': OFF,
+    },
+  },
+  {
+    // テストコードではモック等で any を使いやすくするため警告に緩和
+    files: TEST,
+    rules: {
+      '@typescript-eslint/no-explicit-any': WARN,
+    },
+  },
+];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,36 +1,50 @@
-import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import pluginVue from 'eslint-plugin-vue';
 import prettier from 'eslint-config-prettier';
 import globals from 'globals';
 
-import { importXConfigs } from './configs/eslint/import-x/index.mjs';
-import { unicornConfigs } from './configs/eslint/unicorn/index.mjs';
-import { unusedImportsConfigs } from './configs/eslint/unused-imports/index.mjs';
-import { securityConfigs } from './configs/eslint/security/index.mjs';
-import { sonarjsConfigs } from './configs/eslint/sonarjs/index.mjs';
+import { jsConfigs } from './configs/eslint/js/index.mjs';
 import { nConfigs } from './configs/eslint/n/index.mjs';
+import { sonarjsConfigs } from './configs/eslint/sonarjs/index.mjs';
+import { securityConfigs } from './configs/eslint/security/index.mjs';
+import { unicornConfigs } from './configs/eslint/unicorn/index.mjs';
+import { importXConfigs } from './configs/eslint/import-x/index.mjs';
+import { unusedImportsConfigs } from './configs/eslint/unused-imports/index.mjs';
+import { typescriptConfigs } from './configs/eslint/typescript/index.mjs';
 import { vitestConfigs } from './configs/eslint/vitest/index.mjs';
 
+/**
+ * kei-lisp / kei-lisp-plugin-graphics の eslint.config.mjs と揃えつつ、
+ * Vue アプリ固有の追加を行う。
+ *
+ * 意味のある差分:
+ *   - pluginVue の flat/recommended を追加
+ *   - .vue ファイルは vue-eslint-parser + tseslint.parser の 2 段構成
+ *   - browser globals を含める
+ *   - vue/multi-word-component-names を off（Repl 等の 1 語コンポーネント名を許容）
+ */
 export default [
   {
-    ignores: ['dist/**', 'node_modules/**', '.vite/**'],
+    // env.d.ts は declare module 宣言のみのため lint 対象から外す
+    ignores: ['dist/**', 'node_modules/**', '.vite/**', 'env.d.ts'],
   },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
-  ...pluginVue.configs['flat/recommended'],
-  ...importXConfigs,
-  ...unicornConfigs,
-  ...unusedImportsConfigs,
-  ...securityConfigs,
-  ...sonarjsConfigs,
-  ...nConfigs,
-  ...vitestConfigs,
   {
     languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
       globals: { ...globals.browser, ...globals.node },
     },
   },
+  ...jsConfigs,
+  ...nConfigs,
+  ...sonarjsConfigs,
+  ...securityConfigs,
+  ...unicornConfigs,
+  ...importXConfigs,
+  ...unusedImportsConfigs,
+  ...typescriptConfigs,
+  ...vitestConfigs,
+  ...pluginVue.configs['flat/recommended'],
   {
     files: ['**/*.vue'],
     languageOptions: {
@@ -41,10 +55,9 @@ export default [
     },
   },
   {
+    files: ['**/*.vue'],
     rules: {
       'vue/multi-word-component-names': 'off',
-      // 型定義は interface ではなく type エイリアスを使う方針
-      '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
     },
   },
   prettier,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,6 +43,8 @@ export default [
   {
     rules: {
       'vue/multi-word-component-names': 'off',
+      // 型定義は interface ではなく type エイリアスを使う方針
+      '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
     },
   },
   prettier,

--- a/package.json
+++ b/package.json
@@ -56,5 +56,11 @@
   "engines": {
     "node": ">=20.19.0"
   },
-  "packageManager": "pnpm@10.30.3"
+  "packageManager": "pnpm@10.30.3",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "unrs-resolver"
+    ]
+  }
 }

--- a/src/shims/installProcessShim.test.ts
+++ b/src/shims/installProcessShim.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { installProcessShim } from './installProcessShim';
 import { useReplOutput } from '../composables/useReplOutput';
+import { installProcessShim } from './installProcessShim';
 
 type FakeStream = { write(chunk: unknown): boolean };
 type FakeProcess = { stdout: FakeStream; stderr: FakeStream };

--- a/src/shims/installProcessShim.test.ts
+++ b/src/shims/installProcessShim.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { installProcessShim } from './installProcessShim';
+import { useReplOutput } from '../composables/useReplOutput';
+
+type FakeStream = { write(chunk: unknown): boolean };
+type FakeProcess = { stdout: FakeStream; stderr: FakeStream };
+
+const createFakeProcess = (): FakeProcess =>
+  ({ stdout: undefined, stderr: undefined }) as unknown as FakeProcess;
+
+describe('installProcessShim', () => {
+  beforeEach(() => {
+    useReplOutput().value = '';
+  });
+
+  it('assigns stdout / stderr with a working write function', () => {
+    const fake = createFakeProcess();
+    installProcessShim(fake);
+    expect(typeof fake.stdout.write).toBe('function');
+    expect(typeof fake.stderr.write).toBe('function');
+  });
+
+  it('routes stdout writes to the shared REPL output ref', () => {
+    const fake = createFakeProcess();
+    installProcessShim(fake);
+    fake.stdout.write('hello');
+    expect(useReplOutput().value).toBe('hello');
+  });
+
+  it('routes stderr writes to the shared REPL output ref', () => {
+    const fake = createFakeProcess();
+    installProcessShim(fake);
+    fake.stderr.write('boom');
+    expect(useReplOutput().value).toBe('boom');
+  });
+});

--- a/src/shims/installProcessShim.ts
+++ b/src/shims/installProcessShim.ts
@@ -22,9 +22,7 @@ type ProcessLike = {
  * @param target - process-like object to patch. Defaults to the global
  *   `process`. Overridable for testing.
  */
-export const installProcessShim = (
-  target: ProcessLike = process as unknown as ProcessLike,
-): void => {
+export const installProcessShim = (target: ProcessLike = process): void => {
   const replOutput = useReplOutput();
   const sink: MinimalWritable = {
     write(chunk) {

--- a/src/shims/installProcessShim.ts
+++ b/src/shims/installProcessShim.ts
@@ -1,13 +1,13 @@
 import { useReplOutput } from '../composables/useReplOutput';
 
-interface MinimalWritable {
+type MinimalWritable = {
   write(chunk: unknown): boolean;
-}
+};
 
-interface ProcessLike {
+type ProcessLike = {
   stdout: MinimalWritable;
   stderr: MinimalWritable;
-}
+};
 
 /**
  * Install minimal `stdout` / `stderr` sinks on the given process-like object

--- a/src/shims/installProcessShim.ts
+++ b/src/shims/installProcessShim.ts
@@ -1,17 +1,37 @@
 import { useReplOutput } from '../composables/useReplOutput';
 
+interface MinimalWritable {
+  write(chunk: unknown): boolean;
+}
+
+interface ProcessLike {
+  stdout: MinimalWritable;
+  stderr: MinimalWritable;
+}
+
 /**
- * Replace `process.stdout.write` / `process.stderr.write` with sinks that
- * append to the shared REPL output ref. Must be called before
- * `new LispInterpreter()` is constructed so that `StreamManager` captures the
- * patched references.
+ * Install minimal `stdout` / `stderr` sinks on the given process-like object
+ * that route to the shared REPL output ref. The browser polyfill
+ * (`process/browser`) used by vite-plugin-node-polyfills omits `stdout` and
+ * `stderr`, so kei-lisp's `print` / `printc` / `terpri` / `format` builtins
+ * would fail without this.
+ *
+ * Must be called before `new LispInterpreter()` so that `StreamManager`
+ * captures the shimmed references at construction time.
+ *
+ * @param target - process-like object to patch. Defaults to the global
+ *   `process`. Overridable for testing.
  */
-export const installProcessShim = (): void => {
+export const installProcessShim = (
+  target: ProcessLike = process as unknown as ProcessLike,
+): void => {
   const replOutput = useReplOutput();
-  const sink = (chunk: unknown): boolean => {
-    replOutput.value += String(chunk);
-    return true;
+  const sink: MinimalWritable = {
+    write(chunk) {
+      replOutput.value += String(chunk);
+      return true;
+    },
   };
-  process.stdout.write = sink as typeof process.stdout.write;
-  process.stderr.write = sink as typeof process.stderr.write;
+  target.stdout = sink;
+  target.stderr = sink;
 };


### PR DESCRIPTION
## 症状

GitHub Pages のビルドは成功して配信されているのに、開くと真っ白な画面（\`<div id=\"app\"></div>\` のまま）。

## 原因

\`vite-plugin-node-polyfills\` が使う \`process/browser\` polyfill には **\`stdout\` / \`stderr\` プロパティが存在しない**（\`process.on\` や \`process.nextTick\` 等はある）。

一方、これまでの \`installProcessShim\` は:

\`\`\`ts
process.stdout.write = sink as typeof process.stdout.write;
process.stderr.write = sink as typeof process.stderr.write;
\`\`\`

と書いていた。ブラウザで \`process.stdout\` は \`undefined\` なので **\`undefined.write = ...\` で TypeError**、main.ts の初期化が失敗し、Vue アプリが mount される前に落ちるため画面が真っ白になっていた。

dev サーバのスモーク確認では \"HTML と JS が配信されている\" ことしか見ておらず、実行時エラーを見逃していた。

## 修正

- \`process.stdout\` / \`process.stderr\` に **\`{ write: sink }\` オブジェクトを直接代入**する形に変更（write のみを持つ最小 WritableLike）
- \`installProcessShim\` に **テスト用の \`target\` 引数**（デフォルトは global \`process\`）を追加
- \`installProcessShim.test.ts\` を追加、stdout / stderr 双方が REPL 出力 ref にルーティングされることを検証

## 検証

- [x] \`pnpm typecheck\` ✓
- [x] \`pnpm check\` (format + lint + spell) ✓
- [x] \`pnpm test\` ✓ 5 件
- [x] \`pnpm build\` ✓ → 生成 bundle 内に \`.stdout=\` / \`.stderr=\` 代入が含まれることを確認
- [ ] マージ後、GitHub Pages の本番 URL で REPL がマウントされ \`(+ 1 2)\` 等が評価できることを確認
- [ ] \`(gopen)\` \`(gfill-rect ...)\` \`(gclose)\` で Canvas に描画されることを確認